### PR TITLE
Cradio: Use &mt instead of &ht

### DIFF
--- a/config/cradio.keymap
+++ b/config/cradio.keymap
@@ -12,22 +12,10 @@
 #define SYM 3
 
 // define the row modifiers
-#define FRML(k1,k2,k3) &ht LCTRL k1  &ht LALT k2  &ht LCMD k3
-#define FRMR(k1,k2,k3) &ht RCMD k1  &ht RALT k2  &ht RCTRL k3
+#define FRML(k1,k2,k3) &mt LCTRL k1  &mt LALT k2  &mt LCMD k3
+#define FRMR(k1,k2,k3) &mt RCMD k1  &mt RALT k2  &mt RCTRL k3
 
 / {
-    behaviors {
-        ht: hold_tap {
-            compatible = "zmk,behavior-hold-tap";
-            #binding-cells = <2>;
-            flavor = "tap-preferred";
-            tapping-term-ms = <220>;
-            quick-tap-ms = <150>;
-            require-prior-idle-ms = <100>;
-            bindings = <&kp>, <&kp>;
-        };
-    };
-
     keymap {
         compatible = "zmk,keymap";
         colemak_layer {
@@ -40,7 +28,7 @@
             &kp A      &kp R      &kp S      &kp T      &kp D          &kp H      &kp N      &kp E      &kp I      &kp O
         //├──────────┼──────────┼──────────┼──────────┼──────────┤   ├──────────┼──────────┼──────────┼──────────┼──────────┤
         //│  Z       │  X       │  C       │  V       │  B       │   │  K       │  M       │ , <      │ . >      │ / ?      │
-          &ht LSHFT Z  &kp X      &kp C      &kp V      &kp B          &kp K      &kp M      &kp COMMA  &kp DOT  &ht RSHFT FSLH
+          &mt LSHFT Z  &kp X      &kp C      &kp V      &kp B          &kp K      &kp M      &kp COMMA  &kp DOT  &mt RSHFT FSLH
         //╰──────────┴──────────┴──────────┼──────────┼──────────┤   ├──────────┼──────────┼──────────┴──────────┴──────────╯
                                            &lt SYM BSPC &kp SPACE    &lt NAV ENTER &mo NUM
         //                                 ╰──────────┴──────────╯   ╰──────────┴──────────╯


### PR DESCRIPTION
According to the [documentation of &mt](https://zmk.dev/docs/behaviors/mod-tap), it should work exactly how I configured `&ht` but it allows me to simplify my configuration.