### PR TITLE
config/cradio: swap the thumb keys on each half

### DIFF
--- a/assets/my_keymap.svg
+++ b/assets/my_keymap.svg
@@ -256,22 +256,22 @@ path.combo { stroke: #7f7f7f; }
 </g>
 <g transform="translate(221, 221) rotate(15.0)" class="key keypos-30">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-<text x="0" y="0" class="key tap">BSPC</text>
+<text x="0" y="0" class="key tap">SPACE</text>
 <text x="0" y="24" class="key hold">symbols</text>
 </g>
 <g transform="translate(279, 245) rotate(30.0)" class="key keypos-31">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-<text x="0" y="0" class="key tap">SPACE</text>
+<text x="0" y="0" class="key tap">BSPC</text>
 <text x="0" y="24" class="key hold">system</text>
 </g>
 <g transform="translate(393, 245) rotate(-30.0)" class="key keypos-32">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-<text x="0" y="0" class="key tap">ENTER</text>
-<text x="0" y="24" class="key hold"><tspan style="font-size: 70%">navigation</tspan></text>
+<text x="0" y="0" class="key tap"><tspan style="font-size: 70%">navigation</tspan></text>
 </g>
 <g transform="translate(451, 221) rotate(-15.0)" class="key keypos-33">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-<text x="0" y="0" class="key tap">numbers</text>
+<text x="0" y="0" class="key tap">ENTER</text>
+<text x="0" y="24" class="key hold">numbers</text>
 </g>
 </g>
 </g>

--- a/config/cradio.keymap
+++ b/config/cradio.keymap
@@ -54,7 +54,7 @@
         //│  Z       │  X       │  C       │  V       │  B       │   │  K       │  M       │ , <      │ . >      │ / ?      │
           &mt LSHFT Z  &kp X      &kp C      &kp V      &kp B          &kp K      &kp M      &kp COMMA  &kp DOT  &mt RSHFT FSLH
         //╰──────────┴──────────┴──────────┼──────────┼──────────┤   ├──────────┼──────────┼──────────┴──────────┴──────────╯
-                                           &lt SYM BSPC &lt SYS SPACE &lt NAV ENTER &mo NUM
+                                           &lt SYM SPACE &lt SYS BSPC &mo NAV &lt NUM ENTER 
         //                                 ╰──────────┴──────────╯   ╰──────────┴──────────╯
             >;
         };


### PR DESCRIPTION
Surprisingly, this keyboard feels quite different than my ErgoDox EZ, especially for how far the home row is from the thumb keys. Naturally, my fingers are resting on the first thumb key (as opposite to the second one on ErgoDox EZ); Swapping them makes more sense.

![my_keymap](https://github.com/user-attachments/assets/c8f3706a-71e6-4b5a-8428-0f78c6eee8d2)
