### PR TITLE
config/cradio: Enable deep sleep after 15 minutes

### DIFF
--- a/config/cradio.conf
+++ b/config/cradio.conf
@@ -1,2 +1,3 @@
+# Enable deep sleep after a default timeout of 15 minutes of inactivity
 # https://zmk.dev/docs/config/power
 CONFIG_ZMK_SLEEP=y

--- a/config/cradio.conf
+++ b/config/cradio.conf
@@ -1,0 +1,2 @@
+# https://zmk.dev/docs/config/power
+CONFIG_ZMK_SLEEP=y


### PR DESCRIPTION
Enable the deep sleep feature that puts the Keyboard into a deep sleep and disconnects Bluetooth. The default timeout is 15 minutes and I kept the default 👉 https://zmk.dev/docs/config/power