### PR TITLE
config/cradio: Increase Bluetooth TZ, enable experimental features

### DIFF
--- a/config/cradio.conf
+++ b/config/cradio.conf
@@ -8,5 +8,5 @@ CONFIG_ZMK_SLEEP=y
 # increasing TX power as well as experimental Bluetooth features solves the
 # problem:
 # https://github.com/zmkfirmware/zmk/issues/916#issuecomment-1943816527
-CONFIG_ZMK_BLE_EXPERIMENTAL_FEATURES=y
 CONFIG_BT_CTLR_TX_PWR_PLUS_8=y
+CONFIG_ZMK_BLE_EXPERIMENTAL_FEATURES=y

--- a/config/cradio.conf
+++ b/config/cradio.conf
@@ -1,3 +1,12 @@
 # Enable deep sleep after a default timeout of 15 minutes of inactivity
 # https://zmk.dev/docs/config/power
 CONFIG_ZMK_SLEEP=y
+
+# When I put down the keyboard halves on both sides of my body (keyboard halves
+# separated by my legs), the right side has a problem connecting to the left
+# side and it's quite misbehaving; I saw a comment on an issue upstream that
+# increasing TX power as well as experimental Bluetooth features solves the
+# problem:
+# https://github.com/zmkfirmware/zmk/issues/916#issuecomment-1943816527
+CONFIG_ZMK_BLE_EXPERIMENTAL_FEATURES=y
+CONFIG_BT_CTLR_TX_PWR_PLUS_8=y


### PR DESCRIPTION
- Enable Bluetooth experimental features documented [here](https://zmk.dev/docs/config/bluetooth). This should improve the Bluetooth connection quality.
- Increase the transmit power of the keyboard's BLE radio documented [here](https://zmk.dev/docs/troubleshooting/connection-issues#unreliableweak-connection).