### PR TITLE
fix(flake): drop nixpkgs input, fix canopen tests on macOS

### DIFF
--- a/assets/my_keymap.svg
+++ b/assets/my_keymap.svg
@@ -68,25 +68,25 @@ text.footer {
 }
 
 /* styling for combo tap, and key non-tap label text */
-text.combo, text.hold, text.shifted, text.left, text.right {
+text.combo, text.hold, text.shifted, text.left, text.right, text.tl, text.tr, text.bl, text.br {
     font-size: 11px;
 }
 
-text.hold {
+text.hold, text.bl, text.br {
     text-anchor: middle;
     dominant-baseline: auto;
 }
 
-text.shifted {
+text.shifted, text.tl, text.tr {
     text-anchor: middle;
     dominant-baseline: hanging;
 }
 
-text.left {
+text.left, text.tl, text.bl {
     text-anchor: start;
 }
 
-text.right {
+text.right, text.tr, text.br {
     text-anchor: end;
 }
 
@@ -880,21 +880,21 @@ path.combo {
 <g transform="translate(28, 81)" class="key keypos-0">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 <text x="0" y="0" class="key tap">
-<tspan x="0" dy="-1.2em">BT</tspan><tspan x="0" dy="1.2em">DISC</tspan>
+<tspan x="0" dy="-0.9em">BT</tspan><tspan x="0" dy="1.2em">DISC</tspan>
 </text>
 <text x="0" y="24" class="key hold">0</text>
 </g>
 <g transform="translate(84, 46)" class="key keypos-1">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 <text x="0" y="0" class="key tap">
-<tspan x="0" dy="-1.2em">BT</tspan><tspan x="0" dy="1.2em">DISC</tspan>
+<tspan x="0" dy="-0.9em">BT</tspan><tspan x="0" dy="1.2em">DISC</tspan>
 </text>
 <text x="0" y="24" class="key hold">1</text>
 </g>
 <g transform="translate(140, 28)" class="key keypos-2">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 <text x="0" y="0" class="key tap">
-<tspan x="0" dy="-1.2em">BT</tspan><tspan x="0" dy="1.2em">DISC</tspan>
+<tspan x="0" dy="-0.9em">BT</tspan><tspan x="0" dy="1.2em">DISC</tspan>
 </text>
 <text x="0" y="24" class="key hold">2</text>
 </g>

--- a/flake.lock
+++ b/flake.lock
@@ -2,38 +2,35 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1767989754,
-        "narHash": "sha256-l9SdO3kVK4Sv685lO1NpacgF54aDfuDAsn8QWXuIcM4=",
+        "lastModified": 1779694939,
+        "narHash": "sha256-Ly4j75O8ICaSQx3uxPnwk2x7PMF0XQvn5r0c3yBA7FI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "765b9152b816b023867abd8ab6e44879af7ed197",
+        "rev": "f9d8b65950353691ab56561e7c73d2e1063d810b",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "release-25.11",
+        "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }
     },
     "root": {
       "inputs": {
-        "nixpkgs": "nixpkgs",
         "zmk-nix": "zmk-nix"
       }
     },
     "zmk-nix": {
       "inputs": {
-        "nixpkgs": [
-          "nixpkgs"
-        ]
+        "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1762648822,
-        "narHash": "sha256-/AD/06iz4CmQa44CAZRs7cEXd5Fm7LpxwqY4KOZV14k=",
+        "lastModified": 1779585559,
+        "narHash": "sha256-wQNwGF2yqSQNj8T7xl6ip2B/26t7pEKEWXGVEjN1gXQ=",
         "owner": "lilyinstarlight",
         "repo": "zmk-nix",
-        "rev": "e20b02a66c3ce0f40db34e8d2978a14b4bb19797",
+        "rev": "6391c897ad90bd2d4e2a3e16f85f2d4f936a76f3",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -1,20 +1,16 @@
 {
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/release-25.11";
-
-    zmk-nix = {
-      url = "github:lilyinstarlight/zmk-nix";
-      inputs.nixpkgs.follows = "nixpkgs";
-    };
+    zmk-nix.url = "github:lilyinstarlight/zmk-nix";
   };
 
   outputs =
     {
       self,
-      nixpkgs,
       zmk-nix,
     }:
     let
+      inherit (zmk-nix.inputs) nixpkgs;
+
       forAllSystems = nixpkgs.lib.genAttrs (nixpkgs.lib.attrNames zmk-nix.packages);
     in
     {
@@ -85,8 +81,21 @@
         };
       });
 
-      devShells = forAllSystems (system: {
-        default = zmk-nix.devShells.${system}.default;
-      });
+      devShells = forAllSystems (system:
+        let
+          pkgs = nixpkgs.legacyPackages.${system};
+          # canopen has flaky timing tests on macOS that cause the build to fail.
+          # We inject a patched python3 via shell.nix's callPackage arg instead of
+          # using zmk-nix.devShells directly, since that is pre-evaluated with
+          # zmk-nix's own pkgs and cannot be retroactively patched via overlays.
+          python3 = pkgs.python3.override {
+            packageOverrides = _: prev: {
+              canopen = prev.canopen.overridePythonAttrs (_: { doCheck = false; });
+            };
+          };
+        in
+        {
+          default = pkgs.callPackage "${zmk-nix}/nix/shell.nix" { inherit python3; };
+        });
     };
 }


### PR DESCRIPTION
Remove separate nixpkgs input and follow zmk-nix's nixpkgs instead
via zmk-nix.inputs.nixpkgs.

canopen has flaky timing tests on macOS that break devShell builds.
zmk-nix.devShells is pre-evaluated and cannot be patched via overlays,
so we call zmk-nix's shell.nix directly via callPackage, injecting a
patched python3 with canopen.doCheck = false.