### PR TITLE
fix(toucan): slow scroll speed from 1/5 to 1/20

### DIFF
--- a/boards/shields/toucan/toucan.dtsi
+++ b/boards/shields/toucan/toucan.dtsi
@@ -112,7 +112,7 @@
             layers = <1 2>;
             input-processors = <
                 &zip_xy_to_scroll_mapper
-                &zip_scroll_scaler 1 5
+                &zip_scroll_scaler 1 20
                 &zip_scroll_transform INPUT_TRANSFORM_X_INVERT
             >;
         };


### PR DESCRIPTION
Stacked on #208.

## Summary

The default upstream scroll speed (`1/5`) is far too fast to be usable.
Change `zip_scroll_scaler` divisor from `5` → `20`, giving 4× slower
scroll — tested and confirmed comfortable.

## Why not Kconfig

Scroll speed is set in DTS (`&zip_scroll_scaler`). Zephyr processes DTS
**before** Kconfig, so `CONFIG_*` values are not available at DTS
preprocessing time in ZMK v0.3. Making it user-configurable upstream is
fundamentally not possible with the current build order; vendoring the
shield (done in #208) is the only viable path.

## Changes

- `boards/shields/toucan/toucan.dtsi`: `&zip_scroll_scaler 1 5` → `&zip_scroll_scaler 1 20`

## Test plan

- [x] `nix build .#toucan.firmware` produces `zmk_left.uf2` and `zmk_right.uf2`
- [x] Flashed and confirmed scroll is noticeably slower and comfortable

🤖 Generated with [Claude Code](https://claude.com/claude-code)