### PR TITLE
feat(display): bounce toucan + layer names on nice!view

### DIFF
--- a/boards/shields/nice_view_gem/assets/images.c
+++ b/boards/shields/nice_view_gem/assets/images.c
@@ -70,6 +70,51 @@ const lv_img_dsc_t profiles = {
     .data = profiles_map,
 };
 
+/* Toucan silhouette — 32×17, 1-bit indexed (index 0 = black, index 1 = white)
+ *
+ * Profile facing right:
+ *   rows 0-2  : head (narrow, top-left)
+ *   row  3    : head + eye (hole at col 2) + beak begins
+ *   rows 4-8  : beak extends right, tapering toward tip
+ *   rows 9-12 : compact body below beak
+ *   rows 13-16: tail feathers tapering down-left
+ */
+#ifndef LV_ATTRIBUTE_IMG_TOUCAN
+#define LV_ATTRIBUTE_IMG_TOUCAN
+#endif
+
+const LV_ATTRIBUTE_MEM_ALIGN LV_ATTRIBUTE_LARGE_CONST LV_ATTRIBUTE_IMG_TOUCAN uint8_t toucan_map[] = {
+    0x00, 0x00, 0x00, 0xff, /*Color of index 0 — black (background)*/
+    0xff, 0xff, 0xff, 0xff, /*Color of index 1 — white (toucan)*/
+    /* row  0: head top (cols 2-6)          */ 0x3E, 0x00, 0x00, 0x00,
+    /* row  1: head (cols 1-7)              */ 0x7F, 0x00, 0x00, 0x00,
+    /* row  2: head+body (cols 0-8)         */ 0xFF, 0x80, 0x00, 0x00,
+    /* row  3: eye@col2, beak to col 23     */ 0xDF, 0xFF, 0xFF, 0x00,
+    /* row  4: beak widest (cols 0-25)      */ 0xFF, 0xFF, 0xFF, 0xC0,
+    /* row  5: beak (cols 0-23)             */ 0xFF, 0xFF, 0xFF, 0x00,
+    /* row  6: beak tapering (cols 0-21)    */ 0xFF, 0xFF, 0xFC, 0x00,
+    /* row  7: beak tapering (cols 1-19)    */ 0x7F, 0xFF, 0xF0, 0x00,
+    /* row  8: beak tip (cols 2-15)         */ 0x3F, 0xFF, 0x00, 0x00,
+    /* row  9: body/neck (cols 3-12)        */ 0x1F, 0xF8, 0x00, 0x00,
+    /* row 10: body (cols 2-11)             */ 0x3F, 0xF0, 0x00, 0x00,
+    /* row 11: body (cols 1-10)             */ 0x7F, 0xE0, 0x00, 0x00,
+    /* row 12: body+tail start (cols 0-9)   */ 0xFF, 0xC0, 0x00, 0x00,
+    /* row 13: tail (cols 0-7)              */ 0xFF, 0x00, 0x00, 0x00,
+    /* row 14: tail (cols 0-5)              */ 0xFC, 0x00, 0x00, 0x00,
+    /* row 15: tail (cols 0-3)              */ 0xF0, 0x00, 0x00, 0x00,
+    /* row 16: tail tip (cols 0-1)          */ 0xC0, 0x00, 0x00, 0x00,
+};
+
+const lv_img_dsc_t toucan = {
+    .header.cf = LV_IMG_CF_INDEXED_1BIT,
+    .header.always_zero = 0,
+    .header.reserved = 0,
+    .header.w = 32,
+    .header.h = 17,
+    .data_size = 76,  /* 8 palette + 17 rows × 4 bytes */
+    .data = toucan_map,
+};
+
 /* L Battery */
 #ifndef LV_ATTRIBUTE_IMG_L_BATTERY_100
 #define LV_ATTRIBUTE_IMG_L_BATTERY_100

--- a/boards/shields/nice_view_gem/widgets/layer.c
+++ b/boards/shields/nice_view_gem/widgets/layer.c
@@ -9,21 +9,211 @@
 #include <zmk/keymap.h>
 #include <zmk/matrix.h>
 
+/* ── Display zone ──────────────────────────────────────────────────────────
+ * Center band between battery row (≈y=28) and output/profile row (≈y=138).
+ */
+#define ANIM_ZONE_Y    28
+#define ANIM_ZONE_H   110
 
+/* ── Toucan sprite dimensions (drawn with LVGL primitives) ─────────────── */
+#define SPRITE_W   48
+#define SPRITE_H   40
 
-void draw_layer_status(lv_obj_t *canvas, const struct status_state *state) {
-    lv_draw_label_dsc_t label_dsc;
-    init_label_dsc(&label_dsc, LVGL_FOREGROUND, &quinquefive_24, LV_TEXT_ALIGN_CENTER);
+/* ── Wing flap ─────────────────────────────────────────────────────────────
+ * 12-frame triangle wave → deflection 0-6-0, one full flap per 12 frames.
+ * At 15 fps → ~1.25 flaps/second (natural slow glide).
+ */
+#define FLAP_PERIOD   12          /* frames per complete up-down cycle  */
+#define FLAP_PEAK      6          /* max deflection (px × 4 = extension)*/
 
-    char fallback_layer_name[16]; 
-
-    const char *layer_name = zmk_keymap_layer_name(zmk_keymap_layer_index_to_id(state->layer_index));
-
-    if (layer_name == NULL || layer_name[0] == '\0') {
-        sprintf(fallback_layer_name, "L#%" PRIu8, state->layer_index);
-        
-        layer_name = fallback_layer_name;
+/* ── Wing drawing ──────────────────────────────────────────────────────────
+ *
+ * The wing is a LEFT-ALIGNED triangle drawn BEFORE the head & body.
+ * Its left edge is pinned to sx; it fans rightward.  The head & body
+ * (drawn after, in the same white colour) mask the right portion of the
+ * wing — leaving a clearly visible white wedge to the upper-left of the
+ * head against the black background.
+ *
+ *   Tip:      (sx,    sy+20 − extension)   ← 1-px point, above head
+ *   Root-L:   (sx,    sy+20)               ← left edge of body (masked)
+ *   Root-R:   (sx+14, sy+20)               ← inside body (masked)
+ *
+ * extension = deflection × 4   →   0 (folded) … 24 px (fully spread)
+ *
+ * At full spread the tip clears the top of the head (head starts at sy+0,
+ * tip is at sy−4) and the visible wedge is ~10 px wide at mid-height.
+ */
+static void draw_wing(lv_obj_t *canvas, int16_t sx, int16_t sy,
+                      int deflection) {
+    int extension = deflection * 4;
+    if (extension <= 0) {
+        return; /* wing fully folded — nothing to draw */
     }
 
-    lv_canvas_draw_text(canvas, 0, 70, SCREEN_WIDTH, &label_dsc, layer_name);
+    lv_draw_rect_dsc_t fill;
+    lv_draw_rect_dsc_init(&fill);
+    fill.bg_color    = LVGL_FOREGROUND;
+    fill.bg_opa      = LV_OPA_COVER;
+    fill.border_width = 0;
+    fill.radius      = 0;
+
+    int tip_y   = sy + 20 - extension;
+    int root_y  = sy + 20;
+    int root_rw = 14;               /* full root width (right side masked) */
+    int span    = root_y - tip_y;  /* == extension                        */
+
+    for (int row = tip_y; row < root_y; row++) {
+        int d = row - tip_y;
+        int w = (root_rw * d + span / 2) / span; /* grows 0 → root_rw    */
+        if (w < 1) w = 1;
+        lv_canvas_draw_rect(canvas, sx, row, w, 1, &fill);
+    }
+}
+
+/* ── Toucan body drawing ───────────────────────────────────────────────── */
+
+static void draw_toucan(lv_obj_t *canvas, int16_t sx, int16_t sy,
+                        int deflection) {
+    lv_draw_rect_dsc_t fill;
+    lv_draw_rect_dsc_init(&fill);
+    fill.bg_color    = LVGL_FOREGROUND;
+    fill.bg_opa      = LV_OPA_COVER;
+    fill.border_width = 0;
+
+    /* 1. Wing — drawn first so head/body covers the overlapping portion */
+    draw_wing(canvas, sx, sy, deflection);
+
+    /* 2. Body: 24×20 rounded oval, lower-left */
+    fill.radius = LV_RADIUS_CIRCLE;
+    lv_canvas_draw_rect(canvas, sx + 0, sy + 18, 24, 20, &fill);
+
+    /* 3. Head: 22×22 filled circle centred at (sx+19, sy+11) */
+    lv_canvas_draw_rect(canvas, sx + 8, sy + 0, 22, 22, &fill);
+
+    /* 4. Beak: 25 column-slices, linearly tapered right-to-point
+     *    half_h = round(4 × (24−c) / 24), centred on row sy+11  */
+    fill.radius = 0;
+    for (int c = 0; c < 25; c++) {
+        int half_h = (4 * (24 - c) + 12) / 24;
+        int h      = 2 * half_h + 1;
+        lv_canvas_draw_rect(canvas, sx + 22 + c, sy + 11 - half_h, 1, h, &fill);
+    }
+
+    /* 5. Tail: 8 tapering horizontal rows, bottom-left */
+    for (int r = 0; r < 8; r++) {
+        int w = 8 - r;
+        lv_canvas_draw_rect(canvas, sx + 0, sy + 32 + r, w, 1, &fill);
+    }
+
+    /* 6. Eye: 3×3 black square punched into the head (last — on top) */
+    lv_draw_rect_dsc_t eye;
+    lv_draw_rect_dsc_init(&eye);
+    eye.bg_color     = LVGL_BACKGROUND;
+    eye.bg_opa       = LV_OPA_COVER;
+    eye.border_width = 0;
+    eye.radius       = 0;
+    lv_canvas_draw_rect(canvas, sx + 12, sy + 5, 3, 3, &eye);
+}
+
+/* ── Animation state ───────────────────────────────────────────────────── */
+
+static struct {
+    int16_t    x, y;        /* sprite / text top-left                    */
+    int8_t     dx, dy;      /* bounce velocity (px/frame)                */
+    int16_t    max_x;       /* horizontal bounce limit                   */
+    int16_t    max_y;       /* vertical bounce limit                     */
+    lv_coord_t text_w;      /* measured width of current layer name      */
+    uint8_t    flap_frame;  /* 0 … FLAP_PERIOD-1, for wing animation    */
+    uint8_t    last_layer;  /* detect layer changes                      */
+} anim = {
+    .x = 8, .y = 8,
+    .dx = 3, .dy = 2,
+    .max_x  = SCREEN_WIDTH - SPRITE_W,
+    .max_y  = ANIM_ZONE_H  - SPRITE_H,
+    .text_w = 0,
+    .flap_frame = 0,
+    .last_layer = 0xFF,
+};
+
+/* ── Helpers ───────────────────────────────────────────────────────────── */
+
+static const char *get_layer_name(uint8_t layer_index,
+                                   char *fallback, size_t sz) {
+    const char *name =
+        zmk_keymap_layer_name(zmk_keymap_layer_index_to_id(layer_index));
+    if (name == NULL || name[0] == '\0') {
+        snprintf(fallback, sz, "L#%" PRIu8, layer_index);
+        return fallback;
+    }
+    return name;
+}
+
+/* ── Public animation API ──────────────────────────────────────────────── */
+
+void layer_animation_reset(uint8_t new_layer) {
+    if (new_layer == anim.last_layer) {
+        return;
+    }
+    anim.last_layer = new_layer;
+
+    if (new_layer == 0) {
+        anim.max_x = SCREEN_WIDTH - SPRITE_W;
+        anim.max_y = ANIM_ZONE_H  - SPRITE_H;
+    } else {
+        char fallback[16];
+        const char *name = get_layer_name(new_layer, fallback, sizeof(fallback));
+        anim.text_w = lv_txt_get_width(name, strlen(name),
+                                        &quinquefive_24, 0, LV_TEXT_FLAG_NONE);
+        anim.max_x  = SCREEN_WIDTH - anim.text_w;
+        if (anim.max_x < 0) { anim.max_x = 0; }
+        anim.max_y  = ANIM_ZONE_H - 24; /* quinquefive_24 cap height */
+    }
+
+    if (anim.x > anim.max_x) { anim.x = anim.max_x / 2; }
+    if (anim.y > anim.max_y) { anim.y = anim.max_y / 2; }
+}
+
+bool layer_animation_tick(uint8_t layer_index) {
+    /* Advance bounce position */
+    anim.x += anim.dx;
+    anim.y += anim.dy;
+
+    if (anim.x <= 0)           { anim.x = 0;           anim.dx = -anim.dx; }
+    if (anim.x >= anim.max_x)  { anim.x = anim.max_x;  anim.dx = -anim.dx; }
+    if (anim.y <= 0)           { anim.y = 0;           anim.dy = -anim.dy; }
+    if (anim.y >= anim.max_y)  { anim.y = anim.max_y;  anim.dy = -anim.dy; }
+
+    /* Advance wing flap only on base layer */
+    if (layer_index == 0) {
+        anim.flap_frame = (anim.flap_frame + 1) % FLAP_PERIOD;
+    }
+
+    return true;
+}
+
+/* ── Draw ──────────────────────────────────────────────────────────────── */
+
+void draw_layer_status(lv_obj_t *canvas, const struct status_state *state) {
+    if (state->layer_index == 0) {
+        /* Triangle-wave deflection: 0 → FLAP_PEAK → 0 over FLAP_PERIOD */
+        int f          = anim.flap_frame;
+        int deflection = (f < FLAP_PERIOD / 2) ? f : (FLAP_PERIOD - f);
+
+        draw_toucan(canvas, anim.x, ANIM_ZONE_Y + anim.y, deflection);
+    } else {
+        lv_draw_label_dsc_t label_dsc;
+        init_label_dsc(&label_dsc, LVGL_FOREGROUND, &quinquefive_24,
+                       LV_TEXT_ALIGN_LEFT);
+
+        char fallback[16];
+        const char *layer_name =
+            get_layer_name(state->layer_index, fallback, sizeof(fallback));
+
+        lv_canvas_draw_text(canvas,
+                            anim.x,
+                            ANIM_ZONE_Y + anim.y,
+                            anim.text_w + 1,
+                            &label_dsc,
+                            layer_name);
+    }
 }

--- a/boards/shields/nice_view_gem/widgets/layer.h
+++ b/boards/shields/nice_view_gem/widgets/layer.h
@@ -8,3 +8,7 @@ struct layer_status_state {
 };
 
 void draw_layer_status(lv_obj_t *canvas, const struct status_state *state);
+
+/* Animation API — called from screen.c */
+void layer_animation_reset(uint8_t new_layer);
+bool layer_animation_tick(uint8_t layer_index);

--- a/boards/shields/nice_view_gem/widgets/screen.c
+++ b/boards/shields/nice_view_gem/widgets/screen.c
@@ -35,6 +35,36 @@ struct connection_status_state {
 
 static sys_slist_t widgets = SYS_SLIST_STATIC_INIT(&widgets);
 
+/* ── Animation timer ────────────────────────────────────────────────────── */
+
+/* Forward declaration — draw_top is defined later in this file */
+static void draw_top(lv_obj_t *widget, lv_color_t cbuf[], const struct status_state *state);
+
+static lv_timer_t *anim_timer = NULL;
+
+static void anim_timer_cb(lv_timer_t *timer) {
+    ARG_UNUSED(timer);
+    struct zmk_widget_screen *widget;
+    SYS_SLIST_FOR_EACH_CONTAINER(&widgets, widget, node) {
+        layer_animation_tick(widget->state.layer_index);
+        draw_top(widget->obj, widget->cbuf3, &widget->state);
+    }
+    /* Timer runs continuously while awake; stopped only on sleep. */
+}
+
+static void start_anim_timer(void) {
+    if (anim_timer == NULL) {
+        anim_timer = lv_timer_create(anim_timer_cb, 67, NULL); /* ~15 fps */
+    }
+}
+
+static void stop_anim_timer(void) {
+    if (anim_timer != NULL) {
+        lv_timer_del(anim_timer);
+        anim_timer = NULL;
+    }
+}
+
 /**
  * Draw buffers
  **/
@@ -137,6 +167,7 @@ ZMK_SUBSCRIPTION(widget_battery_peripheral_status, zmk_peripheral_battery_state_
 
 static void set_layer_status(struct zmk_widget_screen *widget, struct layer_status_state state) {
     widget->state.layer_index = zmk_keymap_highest_layer_active();
+    layer_animation_reset(widget->state.layer_index);
     draw_top(widget->obj, widget->cbuf3, &widget->state);
 }
 
@@ -216,11 +247,13 @@ static int display_activity_event_handler(const zmk_event_t *eh) {
     switch (ev->state) {
     case ZMK_ACTIVITY_ACTIVE:
         set_sleep_screen_active(false);
+        start_anim_timer(); /* resume bouncing on wake */
         // No need to force a redraw, it will happen automatically if really coming back from sleep (ACTIVE also comes after IDLE)
         //force_redraw_all_widgets();
         break;
     case ZMK_ACTIVITY_SLEEP:
         set_sleep_screen_active(true);
+        stop_anim_timer(); /* halt animation before deep sleep */
         force_redraw_all_widgets();
         // Force LVGL to process pending updates and flush to display hardware
         // before the CPU enters deep sleep
@@ -253,6 +286,7 @@ int zmk_widget_screen_init(struct zmk_widget_screen *widget, lv_obj_t *parent) {
     widget_battery_peripheral_status_init();
     widget_layer_status_init();
     widget_output_status_init();
+    start_anim_timer(); /* kick off bouncing immediately on base layer */
 
     return 0;
 }


### PR DESCRIPTION
## Summary

- Adds a continuous ~15 fps animation to the nice!view Sharp Memory LCD on
  the left half of the Toucan keyboard.
- **Base layer (COLEMAK):** a 48×40 pixel-art toucan drawn with LVGL
  primitives (oval body, circular head, tapered beak, tapering tail, eye)
  bounces DVD-screensaver style around the animation zone.  Wings flap with
  a 12-frame triangle wave (~1.25 flaps/second): a left-aligned triangle
  fans out from the body's left edge and is naturally masked by the
  head/body — leaving a clearly visible white wedge that grows and shrinks.
- **Non-base layers:** the layer name (SYM, NUM, SYS, NAV, SYSADM, …) also
  bounces around the animation zone using the exact same DVD-style physics.
  Bounce bounds are computed per-layer from the measured text width so the
  name never clips off-screen.
- Animation is driven by a single `lv_timer` at 67 ms (~15 fps), started at
  init and on wake, stopped on `ZMK_ACTIVITY_SLEEP` to avoid draining the
  battery while the keyboard is idle.

## Files changed

- `widgets/layer.c` — complete rewrite: LVGL-primitive toucan, wing flap,
  bounce physics, layer-name bounce with `lv_txt_get_width` clamping
- `widgets/screen.c` — animation timer lifecycle, `layer_animation_reset`
  / `layer_animation_tick` calls, sleep/wake integration
- `widgets/layer.h` — two new public API declarations

## Test plan

- [x] `nix build .#toucan.firmware` passes (left + right UF2 produced)
- [x] Flash left half; base layer shows bouncing toucan with flapping wings
- [x] Switch to SYM/NUM/NAV layer; name bounces around the zone
- [x] Let keyboard go to sleep; animation stops; wake resumes animation