### PR TITLE
fix(display): remove animation timer, draw toucan statically

### DIFF
--- a/boards/shields/nice_view_gem/widgets/layer.c
+++ b/boards/shields/nice_view_gem/widgets/layer.c
@@ -9,40 +9,9 @@
 #include <zmk/keymap.h>
 #include <zmk/matrix.h>
 
-/* ── Display zone ──────────────────────────────────────────────────────────
- * Center band between battery row (≈y=28) and output/profile row (≈y=138).
- */
-#define ANIM_ZONE_Y    28
-#define ANIM_ZONE_H   110
-
 /* ── Toucan sprite dimensions (drawn with LVGL primitives) ─────────────── */
 #define SPRITE_W   48
 #define SPRITE_H   40
-
-/* ── Wing flap ─────────────────────────────────────────────────────────────
- * 12-frame triangle wave → deflection 0-6-0, one full flap per 12 frames.
- * At 15 fps → ~1.25 flaps/second (natural slow glide).
- */
-#define FLAP_PERIOD   12          /* frames per complete up-down cycle  */
-#define FLAP_PEAK      6          /* max deflection (px × 4 = extension)*/
-
-/* ── Wing drawing ──────────────────────────────────────────────────────────
- *
- * The wing is a LEFT-ALIGNED triangle drawn BEFORE the head & body.
- * Its left edge is pinned to sx; it fans rightward.  The head & body
- * (drawn after, in the same white colour) mask the right portion of the
- * wing — leaving a clearly visible white wedge to the upper-left of the
- * head against the black background.
- *
- *   Tip:      (sx,    sy+20 − extension)   ← 1-px point, above head
- *   Root-L:   (sx,    sy+20)               ← left edge of body (masked)
- *   Root-R:   (sx+14, sy+20)               ← inside body (masked)
- *
- * extension = deflection × 4   →   0 (folded) … 24 px (fully spread)
- *
- * At full spread the tip clears the top of the head (head starts at sy+0,
- * tip is at sy−4) and the visible wedge is ~10 px wide at mid-height.
- */
 static void draw_wing(lv_obj_t *canvas, int16_t sx, int16_t sy,
                       int deflection) {
     int extension = deflection * 4;
@@ -115,26 +84,6 @@ static void draw_toucan(lv_obj_t *canvas, int16_t sx, int16_t sy,
     lv_canvas_draw_rect(canvas, sx + 12, sy + 5, 3, 3, &eye);
 }
 
-/* ── Animation state ───────────────────────────────────────────────────── */
-
-static struct {
-    int16_t    x, y;        /* sprite / text top-left                    */
-    int8_t     dx, dy;      /* bounce velocity (px/frame)                */
-    int16_t    max_x;       /* horizontal bounce limit                   */
-    int16_t    max_y;       /* vertical bounce limit                     */
-    lv_coord_t text_w;      /* measured width of current layer name      */
-    uint8_t    flap_frame;  /* 0 … FLAP_PERIOD-1, for wing animation    */
-    uint8_t    last_layer;  /* detect layer changes                      */
-} anim = {
-    .x = 8, .y = 8,
-    .dx = 3, .dy = 2,
-    .max_x  = SCREEN_WIDTH - SPRITE_W,
-    .max_y  = ANIM_ZONE_H  - SPRITE_H,
-    .text_w = 0,
-    .flap_frame = 0,
-    .last_layer = 0xFF,
-};
-
 /* ── Helpers ───────────────────────────────────────────────────────────── */
 
 static const char *get_layer_name(uint8_t layer_index,
@@ -148,71 +97,27 @@ static const char *get_layer_name(uint8_t layer_index,
     return name;
 }
 
-/* ── Public animation API ──────────────────────────────────────────────── */
-
-void layer_animation_reset(uint8_t new_layer) {
-    if (new_layer == anim.last_layer) {
-        return;
-    }
-    anim.last_layer = new_layer;
-
-    if (new_layer == 0) {
-        anim.max_x = SCREEN_WIDTH - SPRITE_W;
-        anim.max_y = ANIM_ZONE_H  - SPRITE_H;
-    } else {
-        char fallback[16];
-        const char *name = get_layer_name(new_layer, fallback, sizeof(fallback));
-        anim.text_w = lv_txt_get_width(name, strlen(name),
-                                        &quinquefive_24, 0, LV_TEXT_FLAG_NONE);
-        anim.max_x  = SCREEN_WIDTH - anim.text_w;
-        if (anim.max_x < 0) { anim.max_x = 0; }
-        anim.max_y  = ANIM_ZONE_H - 24; /* quinquefive_24 cap height */
-    }
-
-    if (anim.x > anim.max_x) { anim.x = anim.max_x / 2; }
-    if (anim.y > anim.max_y) { anim.y = anim.max_y / 2; }
-}
-
-bool layer_animation_tick(uint8_t layer_index) {
-    /* Advance bounce position */
-    anim.x += anim.dx;
-    anim.y += anim.dy;
-
-    if (anim.x <= 0)           { anim.x = 0;           anim.dx = -anim.dx; }
-    if (anim.x >= anim.max_x)  { anim.x = anim.max_x;  anim.dx = -anim.dx; }
-    if (anim.y <= 0)           { anim.y = 0;           anim.dy = -anim.dy; }
-    if (anim.y >= anim.max_y)  { anim.y = anim.max_y;  anim.dy = -anim.dy; }
-
-    /* Advance wing flap only on base layer */
-    if (layer_index == 0) {
-        anim.flap_frame = (anim.flap_frame + 1) % FLAP_PERIOD;
-    }
-
-    return true;
-}
-
 /* ── Draw ──────────────────────────────────────────────────────────────── */
 
 void draw_layer_status(lv_obj_t *canvas, const struct status_state *state) {
     if (state->layer_index == 0) {
-        /* Triangle-wave deflection: 0 → FLAP_PEAK → 0 over FLAP_PERIOD */
-        int f          = anim.flap_frame;
-        int deflection = (f < FLAP_PERIOD / 2) ? f : (FLAP_PERIOD - f);
-
-        draw_toucan(canvas, anim.x, ANIM_ZONE_Y + anim.y, deflection);
+        draw_toucan(canvas,
+                    (SCREEN_WIDTH - SPRITE_W) / 2,
+                    ANIM_ZONE_Y + (ANIM_ZONE_H - SPRITE_H) / 2,
+                    3); /* static mid-flap pose */
     } else {
         lv_draw_label_dsc_t label_dsc;
         init_label_dsc(&label_dsc, LVGL_FOREGROUND, &quinquefive_24,
-                       LV_TEXT_ALIGN_LEFT);
+                       LV_TEXT_ALIGN_CENTER);
 
         char fallback[16];
         const char *layer_name =
             get_layer_name(state->layer_index, fallback, sizeof(fallback));
 
         lv_canvas_draw_text(canvas,
-                            anim.x,
-                            ANIM_ZONE_Y + anim.y,
-                            anim.text_w + 1,
+                            0,
+                            ANIM_ZONE_Y + (ANIM_ZONE_H - 24) / 2,
+                            SCREEN_WIDTH,
                             &label_dsc,
                             layer_name);
     }

--- a/boards/shields/nice_view_gem/widgets/layer.h
+++ b/boards/shields/nice_view_gem/widgets/layer.h
@@ -3,12 +3,12 @@
 #include <lvgl.h>
 #include "util.h"
 
+/* Animation zone bounds — vertical slice of the canvas reserved for layer display */
+#define ANIM_ZONE_Y    28
+#define ANIM_ZONE_H   110
+
 struct layer_status_state {
     uint8_t index;
 };
 
 void draw_layer_status(lv_obj_t *canvas, const struct status_state *state);
-
-/* Animation API — called from screen.c */
-void layer_animation_reset(uint8_t new_layer);
-bool layer_animation_tick(uint8_t layer_index);

--- a/boards/shields/nice_view_gem/widgets/screen.c
+++ b/boards/shields/nice_view_gem/widgets/screen.c
@@ -35,36 +35,6 @@ struct connection_status_state {
 
 static sys_slist_t widgets = SYS_SLIST_STATIC_INIT(&widgets);
 
-/* ── Animation timer ────────────────────────────────────────────────────── */
-
-/* Forward declaration — draw_top is defined later in this file */
-static void draw_top(lv_obj_t *widget, lv_color_t cbuf[], const struct status_state *state);
-
-static lv_timer_t *anim_timer = NULL;
-
-static void anim_timer_cb(lv_timer_t *timer) {
-    ARG_UNUSED(timer);
-    struct zmk_widget_screen *widget;
-    SYS_SLIST_FOR_EACH_CONTAINER(&widgets, widget, node) {
-        layer_animation_tick(widget->state.layer_index);
-        draw_top(widget->obj, widget->cbuf3, &widget->state);
-    }
-    /* Timer runs continuously while awake; stopped only on sleep. */
-}
-
-static void start_anim_timer(void) {
-    if (anim_timer == NULL) {
-        anim_timer = lv_timer_create(anim_timer_cb, 67, NULL); /* ~15 fps */
-    }
-}
-
-static void stop_anim_timer(void) {
-    if (anim_timer != NULL) {
-        lv_timer_del(anim_timer);
-        anim_timer = NULL;
-    }
-}
-
 /**
  * Draw buffers
  **/
@@ -167,8 +137,7 @@ ZMK_SUBSCRIPTION(widget_battery_peripheral_status, zmk_peripheral_battery_state_
 
 static void set_layer_status(struct zmk_widget_screen *widget, struct layer_status_state state) {
     widget->state.layer_index = zmk_keymap_highest_layer_active();
-    layer_animation_reset(widget->state.layer_index);
-    draw_top(widget->obj, widget->cbuf3, &widget->state);
+    draw_top(widget->obj, widget->cbuf, &widget->state);
 }
 
 static void layer_status_update_cb(struct layer_status_state state) {
@@ -247,16 +216,10 @@ static int display_activity_event_handler(const zmk_event_t *eh) {
     switch (ev->state) {
     case ZMK_ACTIVITY_ACTIVE:
         set_sleep_screen_active(false);
-        start_anim_timer(); /* resume bouncing on wake */
-        // No need to force a redraw, it will happen automatically if really coming back from sleep (ACTIVE also comes after IDLE)
-        //force_redraw_all_widgets();
         break;
     case ZMK_ACTIVITY_SLEEP:
         set_sleep_screen_active(true);
-        stop_anim_timer(); /* halt animation before deep sleep */
         force_redraw_all_widgets();
-        // Force LVGL to process pending updates and flush to display hardware
-        // before the CPU enters deep sleep
         lv_task_handler();
         lv_refr_now(NULL);
         break;
@@ -286,7 +249,6 @@ int zmk_widget_screen_init(struct zmk_widget_screen *widget, lv_obj_t *parent) {
     widget_battery_peripheral_status_init();
     widget_layer_status_init();
     widget_output_status_init();
-    start_anim_timer(); /* kick off bouncing immediately on base layer */
 
     return 0;
 }


### PR DESCRIPTION
## Summary

- The 15fps LVGL animation timer introduced in the nice!view bounce feature called full-screen canvas redraws every 67ms. Even after reducing to 5fps with partial zone redraws, CPU load was enough to starve BLE input event processing on the central half, causing the Cirque trackpad to feel jittery and non-smooth (confirmed via `git bisect` — `4d60ca1` was the first bad commit).
- Remove the `lv_timer_create` loop entirely. The display now only redraws on actual state changes (layer, battery, BLE connection), which are infrequent and do not coincide with active trackpad use.
- On the base layer the toucan is drawn statically, centered in the animation zone with wings at mid-flap pose. Layer names on other layers are drawn centered at the vertical midpoint of the zone.
- Fix a pre-existing bug where `set_layer_status` passed `cbuf3` (an unbound buffer) instead of `cbuf` to `draw_top`.

## Test plan

- [x] `nix build .#toucan.firmware` passes
- [x] Flashed left half — trackpad movement is smooth with no jitter
- [x] Toucan displays statically on base layer; layer name displays on other layers
- [x] Sleep screen still activates correctly