### PR TITLE
chore(display): remove unused buffers and includes

### DIFF
--- a/boards/shields/nice_view_gem/widgets/layer.c
+++ b/boards/shields/nice_view_gem/widgets/layer.c
@@ -1,11 +1,9 @@
 #include <zephyr/kernel.h>
-#include <drivers/behavior.h>
 #include <stdio.h>
 #include <string.h>
 
 #include "layer.h"
 #include "../assets/custom_fonts.h"
-#include <zmk/physical_layouts.h>
 #include <zmk/keymap.h>
 #include <zmk/matrix.h>
 

--- a/boards/shields/nice_view_gem/widgets/screen.c
+++ b/boards/shields/nice_view_gem/widgets/screen.c
@@ -11,7 +11,6 @@ LOG_MODULE_DECLARE(zmk, CONFIG_ZMK_LOG_LEVEL);
 #include <zmk/events/endpoint_changed.h>
 #include <zmk/events/layer_state_changed.h>
 #include <zmk/events/usb_conn_state_changed.h>
-#include <zmk/events/wpm_state_changed.h>
 #include <zmk/battery.h>
 #include <zmk/ble.h>
 #include <zmk/display.h>

--- a/boards/shields/nice_view_gem/widgets/screen.h
+++ b/boards/shields/nice_view_gem/widgets/screen.h
@@ -8,8 +8,6 @@ struct zmk_widget_screen {
     sys_snode_t node;
     lv_obj_t *obj;
     lv_color_t cbuf[SCREEN_WIDTH * SCREEN_HEIGHT];
-    lv_color_t cbuf2[SCREEN_WIDTH * SCREEN_HEIGHT];
-    lv_color_t cbuf3[SCREEN_WIDTH * SCREEN_HEIGHT];
     struct status_state state;
 };
 


### PR DESCRIPTION
## Summary

- Remove `cbuf2` and `cbuf3` from `zmk_widget_screen` — they were allocated but never used, wasting ~96KB of RAM (2 × 144×168×2 bytes).
- Drop three unused includes vendored from upstream: `drivers/behavior.h` and `zmk/physical_layouts.h` from `layer.c`, and `zmk/events/wpm_state_changed.h` from `screen.c`.

## Test plan

- [x] `nix build .#toucan.firmware` passes
- [x] Flashed and verified display still works correctly