### PR TITLE
fix(input): bump CONFIG_INPUT_THREAD_STACK_SIZE to 2048

### DIFF
--- a/config/toucan.conf
+++ b/config/toucan.conf
@@ -23,3 +23,14 @@ CONFIG_ZMK_IDLE_SLEEP_TIMEOUT=3600000
 # Regular idle timeout (30 s default).  Cuts Cirque active current
 # 1.7 mA vs 2.9 mA; touchpad wakes in ~300 ms on next press.
 CONFIG_ZMK_IDLE_TIMEOUT=30000
+
+# Zephyr's default INPUT_THREAD_STACK_SIZE is 512 bytes.  On the central,
+# every forwarded trackpad event fans out into: input_report → input msgq →
+# input thread → split_input_handler + activity_input_listener +
+# glidepoint_listener (zip_xy_scaler → mouse HID report path → optional
+# scroll mapper).  Per-thread stack measurements showed the central's input
+# thread exhausted its canary within ~1.5 min of normal trackpad use — the
+# next nested call then corrupted memory adjacent to the input stack,
+# wedging the trackpad and eventually the split link.  Both halves get
+# the bump for symmetry; ~1.5 KB extra RAM is well within budget.
+CONFIG_INPUT_THREAD_STACK_SIZE=2048


### PR DESCRIPTION
## Summary

Fixes the long-standing right-half lock-up where the Cirque trackpad stops responding and the BLE split link eventually times out with `BT_HCI_ERR_CONN_TIMEOUT`, requiring a hard power-cycle of the right peripheral.

Zephyr's default `CONFIG_INPUT_THREAD_STACK_SIZE` is **512 bytes**. On the central, every forwarded trackpad event fans out into:

```
input_report → input msgq → input thread →
  split_input_handler           (forward to mouse listener)
+ activity_input_listener       (k_work_submit to reset idle timer)
+ glidepoint_listener           (zip_xy_scaler → mouse HID report path
                                 → optional zip_scroll_mapper / transform
                                 when the SYM or NUM thumb layer is held)
```

That callchain doesn't fit in 512 bytes. Per-thread high-water-mark measurements showed the central's \`input\` thread dropped from \`free=88\` at boot to \`free=0\` within ~1.5 min of normal trackpad use. Once the canary is overwritten the kernel can no longer measure free space, and the next nested call writes past the stack into adjacent memory. That corruption is what wedges the trackpad and eventually breaks the split GATT link.

The peripheral side was never affected — its input thread only services the local Cirque driver with no proxy/processor fan-out, and consistently sat at \`STK input free=400\` at the default size.

## Evidence

- **Failing build:** \`STK input\` HWM dropped to 0 around 1:37 of uptime, stayed at 0 forever (canary gone), trackpad wedged within ~10 min, supervision-timeout disconnect followed.
- **Patched build:** ~25 000 cumulative trackpad events on the central across many idle/wake cycles, an overnight peripheral \`sys_poweroff\`, and a cold-boot reconnect — zero \`free=0\` snapshots, no spurious disconnects, halves stayed in lockstep.

The old build overflowed at ~2 200 events; the patched build is ~11× past that without incident.

## Cost

~1.5 KB extra RAM on each half (\`512 → 2048\`), well within the central's ~39 % RAM budget.

## Test plan

- [x] \`nix build .#toucan.firmware\` succeeds on both halves
- [x] central FLASH 38.94 % / RAM 34.46 %, peripheral FLASH 23.05 % / RAM 17.67 %
- [x] flash both halves, ~12 h continuous daily use including heavy trackpad
- [x] overnight peripheral \`sys_poweroff\` + morning cold-recovery reconnects cleanly
- [x] no \`STK input free=0\`, no \`reason 0x08\` split disconnects from the bug