### PR TITLE
debug(toucan): opt-in instrumentation for activity, input, conn-params, stack HWM

### DIFF
--- a/boards/shields/toucan/CMakeLists.txt
+++ b/boards/shields/toucan/CMakeLists.txt
@@ -1,0 +1,4 @@
+if(CONFIG_TOUCAN_DEBUG_INSTRUMENTATION)
+  zephyr_library_include_directories(${CMAKE_SOURCE_DIR}/include)
+  zephyr_library_sources(debug_instrumentation.c)
+endif()

--- a/boards/shields/toucan/Kconfig.defconfig
+++ b/boards/shields/toucan/Kconfig.defconfig
@@ -30,4 +30,21 @@ config ZMK_POINTING
 config RGBLED_WIDGET_BATTERY_LEVEL_HIGH
     default 40
 
+config TOUCAN_DEBUG_INSTRUMENTATION
+    bool "Toucan: log activity-state, input-rate, conn-params, stack HWM"
+    default n
+    select THREAD_MONITOR
+    select THREAD_NAME
+    select THREAD_STACK_INFO
+    select INIT_STACKS
+    help
+      Emits diagnostic lines on the toucan_dbg log module so we can correlate
+      ZMK activity-state transitions, input-event rate, BLE LE parameter
+      updates, and per-thread stack high-water-marks against future trackpad
+      or split-link bugs. Runs a 1024-byte monitor thread independent of the
+      system workqueue so it survives a sysworkq deadlock. Daily-driver
+      builds should leave this n. To capture diagnostics over USB CDC ACM,
+      uncomment the matching block in config/toucan.conf which enables
+      ZMK_USB_LOGGING alongside this flag.
+
 endif

--- a/boards/shields/toucan/debug_instrumentation.c
+++ b/boards/shields/toucan/debug_instrumentation.c
@@ -1,0 +1,144 @@
+// Toucan debug instrumentation. Enabled by CONFIG_TOUCAN_DEBUG_INSTRUMENTATION.
+//
+// Emits four kinds of diagnostic lines on the `toucan_dbg` log module so we
+// can correlate the right-half lock-up against actual ZMK state:
+//
+//   1. ACT  — every ZMK activity-state transition (ACTIVE/IDLE/SLEEP)
+//   2. STATE — periodic snapshot every 5 s (current state, ms since the last
+//      input event, total input-event counter)
+//   3. BLE  — every LE connection parameter update (interval/latency/timeout)
+//      reported by the host stack for any connection
+//   4. STK  — per-thread free-stack bytes, walked alongside each STATE snapshot
+//
+// The monitor runs in its own k_thread, NOT on the system workqueue, so a
+// sysworkq deadlock (the leading hypothesis for the trackpad-after-idle hang)
+// still produces STATE/STK output while sysworkq is wedged.
+
+#include <zephyr/kernel.h>
+#include <zephyr/init.h>
+#include <zephyr/input/input.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/bluetooth/bluetooth.h>
+#include <zephyr/bluetooth/conn.h>
+#include <zephyr/sys/atomic.h>
+
+#include <zmk/event_manager.h>
+#include <zmk/events/activity_state_changed.h>
+#include <zmk/activity.h>
+
+LOG_MODULE_REGISTER(toucan_dbg, LOG_LEVEL_INF);
+
+static const char *state_name(enum zmk_activity_state s) {
+    switch (s) {
+    case ZMK_ACTIVITY_ACTIVE:
+        return "ACTIVE";
+    case ZMK_ACTIVITY_IDLE:
+        return "IDLE";
+    case ZMK_ACTIVITY_SLEEP:
+        return "SLEEP";
+    default:
+        return "?";
+    }
+}
+
+// ── Input-event tap ────────────────────────────────────────────────────────
+// INPUT_CALLBACK_DEFINE with NULL fires for every input device. Cheap counter
+// + last-seen timestamp; the existing activity_input_listener already does
+// k_work_submit on every event, so adding atomics here costs nothing.
+
+static atomic_t input_count = ATOMIC_INIT(0);
+static atomic_t input_last_ms = ATOMIC_INIT(0);
+
+static void dbg_input_listener(struct input_event *ev) {
+    atomic_inc(&input_count);
+    atomic_set(&input_last_ms, (atomic_val_t)k_uptime_get_32());
+}
+INPUT_CALLBACK_DEFINE(NULL, dbg_input_listener);
+
+// ── Activity-state listener ────────────────────────────────────────────────
+// Subscribes to zmk_activity_state_changed. Logs every transition with the
+// uptime, ms since the last input event, and total input count so we can
+// answer the central question: did the system actually enter IDLE while the
+// trackpad was in use?
+
+static int dbg_act_listener(const zmk_event_t *eh) {
+    struct zmk_activity_state_changed *ev = as_zmk_activity_state_changed(eh);
+    if (!ev) {
+        return ZMK_EV_EVENT_BUBBLE;
+    }
+    uint32_t now = k_uptime_get_32();
+    uint32_t last_in_ms = (uint32_t)atomic_get(&input_last_ms);
+    int32_t since_input = (int32_t)(now - last_in_ms);
+    LOG_INF("ACT %s @%ums (last_input %dms ago, inputs=%ld)", state_name(ev->state),
+            (unsigned)now, since_input, atomic_get(&input_count));
+    return ZMK_EV_EVENT_BUBBLE;
+}
+ZMK_LISTENER(toucan_dbg_act, dbg_act_listener);
+ZMK_SUBSCRIPTION(toucan_dbg_act, zmk_activity_state_changed);
+
+// ── BLE connection parameter updates ───────────────────────────────────────
+// Confirms or rules out conn-param renegotiation as the trigger. Interval is
+// in 1.25 ms units, timeout in 10 ms units — print derived ms for readability.
+
+static void dbg_le_param_updated(struct bt_conn *conn, uint16_t interval, uint16_t latency,
+                                 uint16_t timeout) {
+    char addr[BT_ADDR_LE_STR_LEN];
+    bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+    // interval * 1.25 ms = interval * 5 / 4
+    unsigned int_us = ((unsigned)interval * 5u * 1000u) / 4u;
+    LOG_INF("BLE %s le_param: int=%u (%u.%03ums) lat=%u to=%u (%ums)", addr, interval,
+            int_us / 1000u, int_us % 1000u, latency, timeout, (unsigned)timeout * 10u);
+}
+
+BT_CONN_CB_DEFINE(toucan_dbg_conn_cb) = {
+    .le_param_updated = dbg_le_param_updated,
+};
+
+// ── Periodic monitor thread + per-thread stack walk ────────────────────────
+// Runs at K_LOWEST_APPLICATION_THREAD_PRIO on its own stack, so a deadlocked
+// system workqueue does not silence it.
+
+static void thread_walker(const struct k_thread *th, void *udata) {
+    ARG_UNUSED(udata);
+    size_t unused = 0;
+    int err = k_thread_stack_space_get(th, &unused);
+    if (err != 0) {
+        return;
+    }
+    const char *name = k_thread_name_get((k_tid_t)th);
+    LOG_INF("  STK %-20s free=%u", name && name[0] ? name : "?", (unsigned)unused);
+}
+
+static void monitor_thread(void *p1, void *p2, void *p3) {
+    ARG_UNUSED(p1);
+    ARG_UNUSED(p2);
+    ARG_UNUSED(p3);
+
+    // Sleep a moment so SYS_INIT and BT init have settled before first log.
+    k_sleep(K_SECONDS(2));
+
+    while (true) {
+        uint32_t now = k_uptime_get_32();
+        uint32_t last_in_ms = (uint32_t)atomic_get(&input_last_ms);
+        int32_t since_input = (int32_t)(now - last_in_ms);
+        LOG_INF("STATE %s @%ums last_input=%dms ago inputs=%ld",
+                state_name(zmk_activity_get_state()), (unsigned)now, since_input,
+                atomic_get(&input_count));
+        k_thread_foreach_unlocked(thread_walker, NULL);
+
+        k_sleep(K_SECONDS(5));
+    }
+}
+
+K_THREAD_STACK_DEFINE(toucan_monitor_stack, 1024);
+static struct k_thread toucan_monitor_data;
+
+static int dbg_init(void) {
+    atomic_set(&input_last_ms, (atomic_val_t)k_uptime_get_32());
+    k_thread_create(&toucan_monitor_data, toucan_monitor_stack,
+                    K_THREAD_STACK_SIZEOF(toucan_monitor_stack), monitor_thread, NULL, NULL,
+                    NULL, K_LOWEST_APPLICATION_THREAD_PRIO, 0, K_NO_WAIT);
+    k_thread_name_set(&toucan_monitor_data, "toucan_dbg");
+    return 0;
+}
+SYS_INIT(dbg_init, APPLICATION, CONFIG_APPLICATION_INIT_PRIORITY);

--- a/boards/shields/toucan/toucan_left.overlay
+++ b/boards/shields/toucan/toucan_left.overlay
@@ -1,5 +1,22 @@
 #include "toucan.dtsi"
 
+/* CDC ACM UART node + chosen console redirect — always declared. The
+ * CDC ACM driver itself is only compiled in when CONFIG_ZMK_USB_LOGGING=y
+ * (pulled in by the diagnostics block in config/toucan.conf). In production
+ * builds the chosen redirect is harmless: with no CDC ACM driver, kernel
+ * logging just has nowhere to go. */
+/ {
+    chosen {
+        zephyr,console = &cdc_acm_uart;
+    };
+};
+
+&zephyr_udc0 {
+    cdc_acm_uart: cdc_acm_uart {
+        compatible = "zephyr,cdc-acm-uart";
+    };
+};
+
 &pinctrl {
     spi0_default: spi0_default {
         group1 {

--- a/boards/shields/toucan/toucan_right.overlay
+++ b/boards/shields/toucan/toucan_right.overlay
@@ -2,6 +2,24 @@
 #include <input/processors.dtsi>
 #include <dt-bindings/zmk/input_transform.h>
 
+/* CDC ACM UART node + chosen console redirect — always declared. The
+ * CDC ACM driver itself is only compiled in when CONFIG_ZMK_USB_LOGGING=y
+ * (pulled in by the diagnostics block in config/toucan.conf). In production
+ * builds the chosen redirect is harmless: with no CDC ACM driver, kernel
+ * logging just has nowhere to go. */
+/ {
+    chosen {
+        zephyr,console = &cdc_acm_uart;
+    };
+};
+
+&zephyr_udc0 {
+    status = "okay";
+    cdc_acm_uart: cdc_acm_uart {
+        compatible = "zephyr,cdc-acm-uart";
+    };
+};
+
 &xiao_i2c {
     status = "disabled";
 };

--- a/config/toucan.conf
+++ b/config/toucan.conf
@@ -34,3 +34,17 @@ CONFIG_ZMK_IDLE_TIMEOUT=30000
 # wedging the trackpad and eventually the split link.  Both halves get
 # the bump for symmetry; ~1.5 KB extra RAM is well within budget.
 CONFIG_INPUT_THREAD_STACK_SIZE=2048
+
+# ── Diagnostics build (opt-in, off in daily-driver image) ─────────────
+# Uncomment the entire block below to enable the toucan_dbg log module
+# plus USB CDC ACM logging on both halves. CONFIG_TOUCAN_DEBUG_INSTRU-
+# MENTATION compiles boards/shields/toucan/debug_instrumentation.c (the
+# ACT/STATE/BLE/STK listeners). The remaining lines enable the USB-CDC-
+# ACM logging path and silence noisy debug output that would otherwise
+# drop critical events from the log buffer. Leave commented for daily
+# driving — production firmware should not ship with these enabled.
+#CONFIG_TOUCAN_DEBUG_INSTRUMENTATION=y
+#CONFIG_ZMK_USB_LOGGING=y
+#CONFIG_INPUT_LOG_LEVEL_WRN=y
+#CONFIG_SPI_LOG_LEVEL_WRN=y
+#CONFIG_LOG_BUFFER_SIZE=8192


### PR DESCRIPTION
## Summary

Stacks on top of #216. Adds the diagnostics that found the input-thread stack overflow. **Off by default** — daily-driver builds get zero overhead.

To enable, uncomment the 5-line block in \`config/toucan.conf\`:

\`\`\`conf
CONFIG_TOUCAN_DEBUG_INSTRUMENTATION=y
CONFIG_ZMK_USB_LOGGING=y
CONFIG_INPUT_LOG_LEVEL_WRN=y
CONFIG_SPI_LOG_LEVEL_WRN=y
CONFIG_LOG_BUFFER_SIZE=8192
\`\`\`

…then \`nix build .#toucan.firmware\`, flash both halves, tail USB CDC ACM on each side.

## What it logs

A dedicated \`toucan_dbg\` log module emits four kinds of lines:

| Tag | When | Tells you |
|---|---|---|
| \`ACT <state> @<ms> last_input <Δ>ms ago inputs=N\` | every activity transition | whether IDLE actually fires while trackpad is in use |
| \`STATE <state> @<ms> last_input=<Δ>ms inputs=N\` | every 5 s from a dedicated monitor thread (not sysworkq) | a >5 s gap = sysworkq deadlock — monitor still runs on its own stack |
| \`BLE <addr> le_param: int=… lat=… to=…\` | every host \`le_param_updated\` callback | confirms / rules out conn-param renegotiation |
| \`STK <name> free=<bytes>\` | per thread, alongside each STATE | catches overflow on \`input\`, \`bt_rx\`, \`bt_tx\`, sysworkq, the 756-byte \`Split Peripheral Notification Queue\`, etc. |

The monitor thread runs on its own 1024-byte stack at \`K_LOWEST_APPLICATION_THREAD_PRIO\`, so a deadlocked system workqueue does not silence it.

## Footprint

| Build | Left FLASH | Left RAM | Right FLASH | Right RAM |
|---|---|---|---|---|
| Production (debug off) | 38.94 % | 34.46 % | 23.05 % | 17.67 % |
| Debug (block uncommented) | 47.37 % | 40.30 % | 28.90 % | 23.48 % |

With the block commented, the only thing this PR adds at runtime is the unused CDC ACM UART node + \`chosen\` redirect in the DT — both dormant because the CDC ACM driver isn't compiled.

## Test plan

- [x] \`nix build .#toucan.firmware\` succeeds in both states (block commented and uncommented)
- [x] production footprint matches #216 alone
- [x] debug build produces \`toucan_dbg\` log lines over USB CDC ACM on both halves
- [x] monitor thread keeps emitting under heavy trackpad load and across idle/wake cycles