### PR TITLE
fix(toucan): raise split_central_split_run_q stack to 4096

### DIFF
--- a/config/toucan_left.conf
+++ b/config/toucan_left.conf
@@ -2,3 +2,11 @@
 # sees both batteries from a single connection.
 CONFIG_ZMK_SPLIT_BLE_CENTRAL_BATTERY_LEVEL_FETCHING=y
 CONFIG_ZMK_SPLIT_BLE_CENTRAL_BATTERY_LEVEL_PROXY=y
+
+# The split_central_split_run_q (shown as "STK ?" in the stack walk) runs
+# zmk_behavior_invoke_binding() for every event forwarded from the right half.
+# Its default 512-byte stack measured free=4 at HWM — one deep behavior call
+# away from silent corruption.  Under sustained heavy use (hold-tap + trackpad,
+# ~31k events over 20 min) the 2048-byte bump also reached free=4 and crashed
+# the central.  Bump to 4096 to give the full hold-tap call chain room.
+CONFIG_ZMK_SPLIT_BLE_CENTRAL_SPLIT_RUN_STACK_SIZE=4096


### PR DESCRIPTION
## Summary

- Bumps `CONFIG_ZMK_SPLIT_BLE_CENTRAL_SPLIT_RUN_STACK_SIZE` from 2048 to 4096 in `config/toucan_left.conf`

The `split_central_split_run_q` work queue (shown as `STK ?` in Zephyr thread dumps) invokes `zmk_behavior_invoke_binding()` for every event forwarded from the right half. Its default 512-byte stack was already bumped to 2048 in a prior fix, but under sustained hold-tap + trackpad use (~31k events over ~20 min) the 2048-byte stack also reached `free=4` at HWM and crashed the central — the right half sees `reason 0x08` (BT_HCI_ERR_CONN_TIMEOUT / supervision timeout).

Instrumentation via `CONFIG_TOUCAN_DEBUG_INSTRUMENTATION` confirmed: boot baseline was `STK ? free=1856`; under heavy use it degraded toward 0 and the central rebooted. Bumping to 4096 gives the full hold-tap call chain headroom; new boot baseline is `STK ? free=3904`, stable through extended sessions.

## Test plan

- [x] Flashed left half with 4096-byte stack
- [x] Run >1 hour under normal use (hold-tap + trackpad, ~60k+ events) — no crash
- [x] `STK ? free=3904` holds at boot baseline throughout session