### PR TITLE
fix(toucan): resolve right-half lock-up (Cirque K_NO_WAIT) + production config

### DIFF
--- a/config/toucan.conf
+++ b/config/toucan.conf
@@ -28,23 +28,32 @@ CONFIG_ZMK_IDLE_TIMEOUT=30000
 # every forwarded trackpad event fans out into: input_report → input msgq →
 # input thread → split_input_handler + activity_input_listener +
 # glidepoint_listener (zip_xy_scaler → mouse HID report path → optional
-# scroll mapper).  Per-thread stack measurements showed the central's input
-# thread exhausted its canary within ~1.5 min of normal trackpad use — the
-# next nested call then corrupted memory adjacent to the input stack,
-# wedging the trackpad and eventually the split link.  Both halves get
-# the bump for symmetry; ~1.5 KB extra RAM is well within budget.
+# scroll mapper).  Per-thread measurements showed the central's input thread
+# exhaust its 512-byte canary within ~1.5 min of trackpad use.  Both halves
+# get the bump for symmetry; ~1.5 KB extra RAM is well within budget.
 CONFIG_INPUT_THREAD_STACK_SIZE=2048
 
+# Defensive headroom — NOT the lock-up fix.  The right-half lock-up was the
+# Cirque driver blocking the system workqueue inside input_report(K_FOREVER),
+# resolved in the cirque-input-module fork (see config/west.yml).  These two
+# queues were nonetheless measured genuinely tight under instrumented load:
+# ZMK's Low Priority Work Queue (battery + BLE conn-state callbacks) at free=120
+# (768-byte default, 84% consumed) and the system workqueue at free=216
+# (2048-byte default, 89%).  Keep the margin.
+CONFIG_ZMK_LOW_PRIORITY_THREAD_STACK_SIZE=2048
+CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=4096
+
 # ── Diagnostics build (opt-in, off in daily-driver image) ─────────────
-# Uncomment the entire block below to enable the toucan_dbg log module
-# plus USB CDC ACM logging on both halves. CONFIG_TOUCAN_DEBUG_INSTRU-
-# MENTATION compiles boards/shields/toucan/debug_instrumentation.c (the
-# ACT/STATE/BLE/STK listeners). The remaining lines enable the USB-CDC-
-# ACM logging path and silence noisy debug output that would otherwise
-# drop critical events from the log buffer. Leave commented for daily
-# driving — production firmware should not ship with these enabled.
+# Uncomment the entire block below to enable the toucan_dbg log module plus USB
+# CDC ACM logging on both halves.  CONFIG_TOUCAN_DEBUG_INSTRUMENTATION compiles
+# boards/shields/toucan/debug_instrumentation.c (the ACT/STATE/BLE/STK listeners
+# plus the system-workqueue heartbeat).  The remaining lines enable the
+# USB-CDC-ACM logging path and bump the log thread/buffer so the stream does not
+# drop critical events.  Leave commented for daily driving — production firmware
+# should not ship with these enabled.
 #CONFIG_TOUCAN_DEBUG_INSTRUMENTATION=y
 #CONFIG_ZMK_USB_LOGGING=y
 #CONFIG_INPUT_LOG_LEVEL_WRN=y
 #CONFIG_SPI_LOG_LEVEL_WRN=y
+#CONFIG_LOG_PROCESS_THREAD_STACK_SIZE=2048
 #CONFIG_LOG_BUFFER_SIZE=8192

--- a/config/toucan_left.conf
+++ b/config/toucan_left.conf
@@ -3,10 +3,9 @@
 CONFIG_ZMK_SPLIT_BLE_CENTRAL_BATTERY_LEVEL_FETCHING=y
 CONFIG_ZMK_SPLIT_BLE_CENTRAL_BATTERY_LEVEL_PROXY=y
 
-# The split_central_split_run_q (shown as "STK ?" in the stack walk) runs
-# zmk_behavior_invoke_binding() for every event forwarded from the right half.
-# Its default 512-byte stack measured free=4 at HWM — one deep behavior call
-# away from silent corruption.  Under sustained heavy use (hold-tap + trackpad,
-# ~31k events over 20 min) the 2048-byte bump also reached free=4 and crashed
-# the central.  Bump to 4096 to give the full hold-tap call chain room.
-CONFIG_ZMK_SPLIT_BLE_CENTRAL_SPLIT_RUN_STACK_SIZE=4096
+# Note: split_central_split_run_q runs at its 512-byte default — no bump needed.
+# Instrumented peak usage was 192 B (free=320) across 81 min of heavy hold-tap +
+# layer + trackpad use (1,953 hold-tap presses, 642 layer switches).  The earlier
+# "free=4" reading that motivated a 4096 bump was a measurement artifact; the
+# crash it was blamed for was the Cirque input_report(K_FOREVER) system-workqueue
+# block, fixed in the cirque-input-module fork (see config/west.yml).

--- a/config/toucan_right.conf
+++ b/config/toucan_right.conf
@@ -1,0 +1,11 @@
+# Peripheral half (right side) — stack tuning beyond the shared toucan.conf.
+
+# The BT HCI TX thread sends every outgoing BLE packet — on the peripheral that
+# includes the Cirque GATT notifications.  Instrumented at free=256 at boot
+# (Zephyr default 1024 bytes, 75% consumed), tight enough to warrant headroom.
+# NOTE: the right-half lock-up was NOT this stack overflowing — it was the Cirque
+# driver blocking the system workqueue inside input_report(K_FOREVER), fixed in
+# the cirque-input-module fork (see config/west.yml).  This bump is kept only as
+# defensive margin.  WITH_PROMPT=y is required to override the derived default.
+CONFIG_BT_HCI_TX_STACK_SIZE_WITH_PROMPT=y
+CONFIG_BT_HCI_TX_STACK_SIZE=2048

--- a/config/west.yml
+++ b/config/west.yml
@@ -6,6 +6,8 @@ manifest:
       url-base: https://github.com/caksoylar
     - name: geeksville
       url-base: https://github.com/geeksville
+    - name: kalbasit
+      url-base: https://github.com/kalbasit
   projects:
     - name: zmk
       remote: zmkfirmware
@@ -34,10 +36,14 @@ manifest:
           - openthread
           - edtt
           - trusted-firmware-m
-    # Cirque trackpad input module (toucan-specific branch)
+    # Cirque trackpad input module — kalbasit fork carrying toucan stability
+    # fixes on top of geeksville's toucan branch (branch: toucan-fixes):
+    #   - re-arm DR IRQ on every early-return path (trackpad-wedge fix)
+    #   - report input with K_NO_WAIT so a full input queue can never block the
+    #     system workqueue (right-half lock-up fix, kalbasit/zmk-config#215)
     - name: cirque-input-module
-      remote: geeksville
-      revision: toucan
+      remote: kalbasit
+      revision: c3e1fcfd8f9fba2e1f8f09ed664822870bce61ca
     # RGB LED widget
     - name: zmk-rgbled-widget
       remote: caksoylar

--- a/flake.nix
+++ b/flake.nix
@@ -41,7 +41,7 @@
             shield = "cradio_%PART%";
             # Run `nix build .#cradio.firmware` to get the actual hash after
             # any west.yml change.
-            zephyrDepsHash = "sha256-vWkof2b17gLgKemffXlEbNKU2qerX2b+ylp0l5lh/xk=";
+            zephyrDepsHash = "sha256-Vi9NYisusYogv+kf0kwadtvQ+SR7LHSnCPCrUliUxQM=";
             meta = {
               description = "ZMK firmware for Cradio (Sweep)";
               license = nixpkgs.lib.licenses.mit;
@@ -65,14 +65,14 @@
               inherit src;
               board = "seeeduino_xiao_ble";
               shield = "toucan_left rgbled_adapter nice_view_gem";
-              zephyrDepsHash = "sha256-vWkof2b17gLgKemffXlEbNKU2qerX2b+ylp0l5lh/xk=";
+              zephyrDepsHash = "sha256-Vi9NYisusYogv+kf0kwadtvQ+SR7LHSnCPCrUliUxQM=";
             };
             right = buildKeyboard {
               name = "toucan-firmware-right";
               inherit src;
               board = "seeeduino_xiao_ble";
               shield = "toucan_right rgbled_adapter";
-              zephyrDepsHash = "sha256-vWkof2b17gLgKemffXlEbNKU2qerX2b+ylp0l5lh/xk=";
+              zephyrDepsHash = "sha256-Vi9NYisusYogv+kf0kwadtvQ+SR7LHSnCPCrUliUxQM=";
               # Reuse the west deps already fetched for the left build.
               westDeps = left.westDeps;
             };


### PR DESCRIPTION
## Summary

Resolves the long-standing right-half lock-up on the Toucan (split + Cirque trackpad).

**Root cause — proven, not a stack overflow.** The Cirque driver's `pinnacle_work_cb` runs on the **system workqueue** and reported every sample with `input_report_*(..., K_FOREVER)`. Once the input message queue backs up behind BLE split-forwarding, that call blocks the system workqueue forever — split forwarding, battery, and kscan debounce all stall, so the right half goes dark with no crash and every stack healthy. A self-rescheduling system-workqueue heartbeat froze at the exact instant input died, proving the queue was blocked, not faulted.

**Fix.** Point the Cirque module at a fork carrying `K_NO_WAIT` input reporting (+ DR-IRQ re-arm on early returns), via `config/west.yml` + `flake.nix` `zephyrDepsHash`. Upstream PRs: geeksville/cirque-input-module#4 (K_NO_WAIT) and #5 (IRQ re-arm).

**Config trimmed to production**, each kept/dropped stack bump backed by per-thread high-water-mark data from an 81-min instrumented soak (heavy trackpad + 1,953 hold-tap presses + 642 layer switches):

- *Kept (load-bearing):* `INPUT_THREAD` 2048 (peak 536 B — overflows the 512 default), `SYSTEM_WORKQUEUE` 4096 (peak 1976 B), `LOW_PRIORITY` 2048 (peak 656 B), peripheral `BT_HCI_TX` 2048.
- *Dropped (unjustified by data):* `split_run_q` 4096 (peak 192 B), `BT_CTLR_RX_PRIO`, `BT_LONG_WQ`, `ZMK_BLE_THREAD`, `SPLIT_BLE_PERIPHERAL`, and the disproven Cirque PM idle-deadlock workaround.
- Debug instrumentation/USB logging disabled for the production image (harness stays opt-in, Kconfig `default n`).

## Test plan

- [x] Builds clean: `nix build .#toucan.firmware`
- [x] Hardware soak: 80+ min heavy trackpad + key use, system-workqueue heartbeat advancing every second throughout, zero lock-ups (the prior build wedged at ~15 min)
- [x] Production image (debug off) flashed and running stable